### PR TITLE
fix yaml load deprecation warning

### DIFF
--- a/gogo_gadget/config.py
+++ b/gogo_gadget/config.py
@@ -7,7 +7,7 @@ import yaml
 def load_config(path):
     with open(path, 'r') as f:
         try:
-            return yaml.load(f)
+            return yaml.load(f, Loader=yaml.FullLoader)
         except yaml.YAMLError as exc:
             msg = "Was not able to read YAML file %s. " \
                   "This is likely a parsing error."


### PR DESCRIPTION
PyYAML intentionally made a breaking change due to security flaw. This is just doing the recommended thing.

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation